### PR TITLE
add configurable_serverapp

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,5 +29,5 @@ jobs:
 #         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest pytest-tornado pytest-asyncio nose
+        pip install pytest pytest-tornasync nose
         pytest

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -6,9 +6,7 @@ from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoi
 
 @pytest.fixture
 def config():
-    c = Config()
-    c.FileContentsManager.checkpoints_class = GenericFileCheckpoints
-    return c
+    return {'FileContentsManager': {'checkpoints_class': GenericFileCheckpoints}}
 
 
 def test_config_did_something(serverapp):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -152,13 +152,17 @@ async def test_gateway_env_options(init_gateway, serverapp):
     assert serverapp.gateway_config.connect_timeout == 44.4
 
 
-async def test_gateway_cli_options():
+async def test_gateway_cli_options(configurable_serverapp):
+    argv = [
+        "--gateway-url='" + mock_gateway_url + "'",
+        "--GatewayClient.http_user='" + mock_http_user + "'",
+        '--GatewayClient.connect_timeout=44.4',
+        '--GatewayClient.request_timeout=44.4'
+    ]
+
+
     GatewayClient.clear_instance()
-    app = ServerApp()
-    app.initialize(["--gateway-url='" + mock_gateway_url + "'",
-                    "--GatewayClient.http_user='" + mock_http_user + "'",
-                    '--GatewayClient.connect_timeout=44.4',
-                    '--GatewayClient.request_timeout=44.4'])
+    app = configurable_serverapp(argv=argv)
 
     assert app.gateway_config.gateway_enabled is True
     assert app.gateway_config.url == mock_gateway_url

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -28,10 +28,9 @@ def test_help_output():
     check_help_all_output('jupyter_server')
 
 
-def test_server_info_file(tmp_path):
-    app = ServerApp(runtime_dir=str(tmp_path), log=logging.getLogger())
+def test_server_info_file(tmp_path, configurable_serverapp):
+    app = configurable_serverapp(log=logging.getLogger())
 
-    app.initialize(argv=[])
     app.write_server_info_file()
     servers = list(list_running_servers(app.runtime_dir))
 
@@ -48,8 +47,8 @@ def test_server_info_file(tmp_path):
     app.remove_server_info_file
 
 
-def test_root_dir(tmp_path):
-    app = ServerApp(root_dir=str(tmp_path))
+def test_root_dir(tmp_path, configurable_serverapp):
+    app = configurable_serverapp(root_dir=str(tmp_path))
     assert app.root_dir == str(tmp_path)
 
 
@@ -69,8 +68,8 @@ def invalid_root_dir(tmp_path, request):
     return str(path)
 
 
-def test_invalid_root_dir(invalid_root_dir):
-    app = ServerApp()
+def test_invalid_root_dir(invalid_root_dir, configurable_serverapp):
+    app = configurable_serverapp()
     with pytest.raises(TraitError):
         app.root_dir = invalid_root_dir
 
@@ -88,8 +87,8 @@ def valid_root_dir(tmp_path, request):
         path.mkdir(parents=True)
     return str(path)
 
-def test_valid_root_dir(valid_root_dir):
-    app = ServerApp(root_dir=valid_root_dir)
+def test_valid_root_dir(valid_root_dir, configurable_serverapp):
+    app = configurable_serverapp(root_dir=valid_root_dir)
     root_dir = valid_root_dir
     # If nested path, the last slash should 
     # be stripped by the root_dir trait.
@@ -98,15 +97,15 @@ def test_valid_root_dir(valid_root_dir):
     assert app.root_dir == root_dir
 
 
-def test_generate_config(tmp_path):
-    app = ServerApp(config_dir=str(tmp_path))
+def test_generate_config(tmp_path, configurable_serverapp):
+    app = configurable_serverapp(config_dir=str(tmp_path))
     app.initialize(['--generate-config', '--allow-root'])
     with pytest.raises(NoStart):
         app.start()
     assert tmp_path.joinpath('jupyter_server_config.py').exists()
 
 
-def test_server_password(tmp_path):
+def test_server_password(tmp_path, configurable_serverapp):
     password = 'secret'
     with patch.dict(
         'os.environ', {'JUPYTER_CONFIG_DIR': str(tmp_path)}
@@ -114,7 +113,7 @@ def test_server_password(tmp_path):
         app = JupyterPasswordApp(log_level=logging.ERROR)
         app.initialize([])
         app.start()
-        sv = ServerApp()
+        sv = configurable_serverapp()
         sv.load_config_file()
         assert sv.password != ''
         passwd_check(sv.password, password)


### PR DESCRIPTION
@kevin-bates Here's my fix for allowing a configurable serverapp fixture. 

If you want a serverapp that you can configure using `argv` or a dictionary of config values, use the `configurable_serverapp` fixture. That fixture handles instance clearing and setting up default jupyter paths/directories, port number, etc.

If a plain, vanilla serverapp is needed, we can just use the `serverapp` fixture.